### PR TITLE
Add myschedule.fraserhealth

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -19,3 +19,8 @@
 1. Go to Chrome Extensions page (chrome://extensions/)
 2. Click Extension "Details"
 3. Under "Inspect views" -> Click service worker
+
+# Managing the published extension
+1. Zip the entire directory `zip -r vch-myschedule-exporter.zip vch-myschedule-exporter -x "*/.git/*"`
+2. In the Chrome Web Store Developer Dashboard, click "Upload new package"
+3. Submit for review

--- a/export.js
+++ b/export.js
@@ -463,7 +463,10 @@ function updateSettings() {
 
 $(document).ready(function () {
     // Show dropdown only if on the "My Shifts" page
-    if (window.location.href.includes('myschedule.vch.ca/employee/sched/readonly/employee')) {
+    if (
+        window.location.href.includes('myschedule.vch.ca/employee/sched/readonly/employee') ||
+        window.location.href.includes('myschedule.fraserhealth.ca/employee/sched/readonly/employee')
+    ) {
         appendExportDiv();
     };
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "VCH MySchedule Exporter",
     "description": "Export work shifts from Vancouver Coastal Health (VCH) MySchedule into an iCalendar file.",
-    "version": "1.2",
+    "version": "1.3",
     "icons": {
         "16": "icons/icon_16.png",
         "32": "icons/icon_32.png",
@@ -18,7 +18,8 @@
     "content_scripts": [
         {
             "matches": [
-                "https://myschedule.vch.ca/employee/sched/readonly/employee*"
+                "https://myschedule.vch.ca/employee/sched/readonly/employee*",
+                "https://myschedule.fraserhealth.ca/employee/sched/readonly/employee*"
             ],
             "all_frames": true,
             "js": [


### PR DESCRIPTION
## Description

Fraserhealth also uses the same system myschedule system. Without access to myschedule.fraserhealth, we assume that the page structure is the same and simply add the base domain.